### PR TITLE
Lrn 45239/bug/update vendors used in example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ sudo: false
 dist: focal
 language: ruby
 rvm:
-  - '2.6'
-  - '2.7'
   - '3.0'
   - '3.1'
+  - '3.2'
 before_install:
   # Login to docker hub
   - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 - Bumped 3rd party libraries to fix known vulnerabilities in the quick start application
 - Fixed seed data for the api-reports example in the quick start application  
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Bumped 3rd party libraries to fix known vulnerabilities in the quick start application
+- Fixed seed data for the api-reports example in the quick start application  
 
 ## [v0.3.0] - 2024-07-12
 ### Added

--- a/docs/quickstart/lrn-sdk-rails/Gemfile
+++ b/docs/quickstart/lrn-sdk-rails/Gemfile
@@ -5,30 +5,29 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 5.0.2'
+gem 'rails', '~> 6.1.0'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.3.6'
+gem 'sqlite3', '~> 1.6.3'
 # Use Puma as the app server
-gem 'puma', '~> 4.3.8'
+gem 'puma', '~> 6.4.0'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+gem 'sass-rails', '~> 5.1.0'
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+gem 'uglifier', '>= 4.2.0'
 # Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.2'
+gem 'coffee-rails', '~> 5.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
+# gem 'mini_racer', platforms: :ruby
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.5'
+gem 'jbuilder', '~> 2.11'
 # Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 3.0'
+# gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
@@ -42,11 +41,11 @@ end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
-  gem 'listen', '~> 3.0.5'
+  gem 'web-console', '>= 4.2.0'
+  gem 'listen', '~> 3.8'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'spring-watcher-listen', '~> 2.1.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/docs/quickstart/lrn-sdk-rails/app/controllers/reports_controller.rb
+++ b/docs/quickstart/lrn-sdk-rails/app/controllers/reports_controller.rb
@@ -17,8 +17,8 @@ class ReportsController < ApplicationController
                           "reports" => [{
                               "id"=> "session-detail",
                               "type"=> "session-detail-by-item",
-                              "user_id"=> "906d564c-39d4-44ba-8ddc-2d44066e2ba9",
-                              "session_id"=> "906d564c-39d4-44ba-8ddc-2d44066e2ba9"
+                              "user_id"=> "student_0001",
+                              "session_id"=> "ef4f80b8-e281-41f4-9efd-349b7eb9dd37"
                           }]
                       }
   def index

--- a/docs/quickstart/lrn-sdk-rails/config/initializers/new_framework_defaults.rb
+++ b/docs/quickstart/lrn-sdk-rails/config/initializers/new_framework_defaults.rb
@@ -18,7 +18,8 @@ ActiveSupport.to_time_preserves_timezone = true
 Rails.application.config.active_record.belongs_to_required_by_default = true
 
 # Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = false
+# This option is not applicable for Rails 6.1 and has been removed.
+# ActiveSupport.halt_callback_chains_on_return_false = false
 
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }


### PR DESCRIPTION
bumps rails from 5.0.2 to 6.1.0
bumps sqlite3 from 1.3.6 to 1.6.3
bumps puma from 4.3.8 to 6.4.0
bumps sass-rails from 5.0 to 5.1.0
bumps uglifier from 1.3.0 to 4.2.0
bumps coffee-rails from 4.2 to 5.0
bumps web-console from 3.3.0 to 4.2.0
bumps listen from 3.0.5 to 3.8
bumps spring-watcher-listen from 2.0.0 to 2.1.0

Removes  the following config which is no long applicable in Rails 6.1
ActiveSupport.halt_callback_chains_on_return_false = false

## Checklist

- [ ] Feature
- [x] Bug
- [x] Security
- [ ] Documentation

- [x] ChangeLog.md updated

- [ ] Tests added
- [x] All testsuites passed
