### PR TITLE
[FEATURE] Add UUID util (LRN-49157)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- UUID generation utility (`Learnosity::Sdk::Uuid.generate()`) for feature parity with Python and Node.js SDKs
+  - Provides a consistent API pattern across all Learnosity SDKs
+  - Lightweight wrapper around Ruby's `SecureRandom.uuid`
+  - Commonly used for generating `user_id` and `session_id` values
+  - Accessible via `Learnosity::Sdk::Uuid.generate`
+  - Comprehensive unit tests included
 - Data API support with dedicated `DataApi` class
   - `request()` method for single authenticated Data API requests
   - `request_iter()` method for iterating through paginated responses
@@ -17,6 +23,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Data API demo added to Rails quickstart application
 - Comprehensive unit and integration tests for Data API functionality
 - Example usage in `examples/simple/data_api_example.rb`
+
+### Changed
+
+- Updated documentation and examples to use `Learnosity::Sdk::Uuid.generate` instead of `SecureRandom.uuid`
+- Updated README.md and REFERENCE.md with UUID utility usage examples
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ We start by including some LearnositySDK helpers in [items_controller.rb](docs/q
 
 ``` ruby
 require 'learnosity/sdk/request/init' # Learnosity helper.
-require 'securerandom'                # Library for generating UUIDs.
+require 'learnosity/sdk'               # For UUID generation utility.
 ```
 
 Now we'll declare the configuration options for Items API. The following options specify which assessment content should be rendered, how it should be displayed, which user is taking this assessment and how their responses should be stored. 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -186,8 +186,15 @@ See `examples/simple/init_data.rb` for an example.
 
 ### Generating UUIDs
 
-You will need to generate UUIDs. You can use the Ruby `securerandom`
-module for this purpose.
+You will need to generate UUIDs for user IDs and session IDs. The SDK provides a convenient utility for this purpose.
+
+```ruby
+require 'learnosity/sdk'
+
+p Learnosity::Sdk::Uuid.generate
+```
+
+Alternatively, you can use the Ruby `securerandom` module directly:
 
 ```ruby
 require 'securerandom'

--- a/docs/quickstart/lrn-sdk-rails/app/controllers/author_controller.rb
+++ b/docs/quickstart/lrn-sdk-rails/app/controllers/author_controller.rb
@@ -1,5 +1,5 @@
 require 'learnosity/sdk/request/init' # Learnosity helper.
-require 'securerandom'
+require 'learnosity/sdk'               # For UUID generation utility.
 
 class AuthorController < ApplicationController
 
@@ -7,7 +7,7 @@ class AuthorController < ApplicationController
     # XXX: This is a Learnosity Demos consumer; replace it with your own consumer key. Set values in application.rb.
     'consumer_key'   => Rails.configuration.consumer_key,
     'domain'         => 'localhost',
-    'user_id'        => SecureRandom.uuid
+    'user_id'        => Learnosity::Sdk::Uuid.generate
   }
 
   # XXX: The consumer secret should be in a properly secured credential store, and *NEVER* checked into version control

--- a/docs/quickstart/lrn-sdk-rails/app/controllers/index_controller.rb
+++ b/docs/quickstart/lrn-sdk-rails/app/controllers/index_controller.rb
@@ -1,5 +1,5 @@
 require 'learnosity/sdk/request/init' # Learnosity helper.
-require 'securerandom'                # Library for generating UUIDs.
+require 'learnosity/sdk'               # For UUID generation utility.
 
 class IndexController < ApplicationController
 

--- a/docs/quickstart/lrn-sdk-rails/app/controllers/items_controller.rb
+++ b/docs/quickstart/lrn-sdk-rails/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 require 'learnosity/sdk/request/init' # Learnosity helper.
-require 'securerandom'                # Library for generating UUIDs.
+require 'learnosity/sdk'               # For UUID generation utility.
 
 class ItemsController < ApplicationController
   @@security_packet = {
@@ -12,9 +12,9 @@ class ItemsController < ApplicationController
   @@consumer_secret = Rails.configuration.consumer_secret
 
   @@items_request = {
-    "user_id" => SecureRandom.uuid,
+    "user_id" => Learnosity::Sdk::Uuid.generate,
     "activity_template_id" => "quickstart_examples_activity_template_001",
-    "session_id" => SecureRandom.uuid,
+    "session_id" => Learnosity::Sdk::Uuid.generate,
     "activity_id" => "quickstart_examples_activity_001",
     "rendering_type" => "assess",
     "type" => "submit_practice",

--- a/docs/quickstart/lrn-sdk-rails/app/controllers/questions_controller.rb
+++ b/docs/quickstart/lrn-sdk-rails/app/controllers/questions_controller.rb
@@ -1,5 +1,5 @@
 require 'learnosity/sdk/request/init' # Learnosity helper.
-require 'securerandom'
+require 'learnosity/sdk'               # For UUID generation utility.
 
 class QuestionsController < ApplicationController
 
@@ -7,7 +7,7 @@ class QuestionsController < ApplicationController
     # XXX: This is a Learnosity Demos consumer; replace it with your own consumer key. Set values in application.rb.
     'consumer_key'   => Rails.configuration.consumer_key,
     'domain'         => 'localhost',
-    'user_id'        => SecureRandom.uuid
+    'user_id'        => Learnosity::Sdk::Uuid.generate
   }
 
   # XXX: The consumer secret should be in a properly secured credential store, and *NEVER* checked into version control

--- a/docs/quickstart/lrn-sdk-rails/app/controllers/reports_controller.rb
+++ b/docs/quickstart/lrn-sdk-rails/app/controllers/reports_controller.rb
@@ -1,5 +1,5 @@
 require 'learnosity/sdk/request/init' # Learnosity helper.
-require 'securerandom'
+require 'learnosity/sdk'               # For UUID generation utility.
 
 class ReportsController < ApplicationController
 
@@ -7,7 +7,7 @@ class ReportsController < ApplicationController
     # XXX: This is a Learnosity Demos consumer; replace it with your own consumer key. Set values in application.rb.
     'consumer_key'   => Rails.configuration.consumer_key,
     'domain'         => 'localhost',
-    'user_id'        => SecureRandom.uuid
+    'user_id'        => Learnosity::Sdk::Uuid.generate
   }
 
   # XXX: The consumer secret should be in a properly secured credential store, and *NEVER* checked into version control

--- a/examples/simple/uuid_example.rb
+++ b/examples/simple/uuid_example.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+require 'bundler/setup'
+require 'learnosity/sdk'
+
+# Example: Generate UUIDs using the Learnosity SDK utility
+# This is commonly used for user_id and session_id in API requests
+
+puts "Generating UUIDs using Learnosity::Sdk::Uuid.generate:"
+puts
+
+# Generate a few UUIDs
+5.times do |i|
+  uuid = Learnosity::Sdk::Uuid.generate
+  puts "UUID #{i + 1}: #{uuid}"
+end
+
+puts
+puts "Example usage in API requests:"
+puts
+
+# Example: Using UUIDs in an Items API request
+user_id = Learnosity::Sdk::Uuid.generate
+session_id = Learnosity::Sdk::Uuid.generate
+
+puts "user_id: #{user_id}"
+puts "session_id: #{session_id}"
+
+# vim: sw=2
+

--- a/lib/learnosity/sdk.rb
+++ b/lib/learnosity/sdk.rb
@@ -1,10 +1,14 @@
 require "learnosity/sdk/version"
 require "learnosity/sdk/request/data_api"
+require "learnosity/sdk/utils/uuid"
 
 module Learnosity
   module Sdk
     # Export DataApi class for convenient access
     DataApi = Request::DataApi
+
+    # Export Uuid utility for convenient access
+    Uuid = Utils::Uuid
   end
 end
 

--- a/lib/learnosity/sdk/utils/uuid.rb
+++ b/lib/learnosity/sdk/utils/uuid.rb
@@ -1,0 +1,21 @@
+require 'securerandom'
+
+module Learnosity
+  module Sdk
+    module Utils
+      # UUID utility for generating UUIDv4 identifiers
+      # Commonly used for user_id and session_id in Learnosity API requests
+      class Uuid
+        # Generate a UUIDv4 string
+        #
+        # @return [String] A UUIDv4 string
+        def self.generate
+          SecureRandom.uuid
+        end
+      end
+    end
+  end
+end
+
+# vim: sw=2
+

--- a/spec/learnosity/sdk/utils/uuid_spec.rb
+++ b/spec/learnosity/sdk/utils/uuid_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "set"
 require "learnosity/sdk/utils/uuid"
 
 RSpec.describe Learnosity::Sdk::Utils::Uuid do

--- a/spec/learnosity/sdk/utils/uuid_spec.rb
+++ b/spec/learnosity/sdk/utils/uuid_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+require "learnosity/sdk/utils/uuid"
+
+RSpec.describe Learnosity::Sdk::Utils::Uuid do
+  describe ".generate" do
+    it "generates a valid UUIDv4 string" do
+      uuid = Learnosity::Sdk::Utils::Uuid.generate
+      
+      # UUIDv4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+      # where y is one of [8, 9, a, b]
+      uuid_v4_regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      
+      expect(uuid).to be_a(String)
+      expect(uuid.length).to eq(36)
+      expect(uuid).to match(uuid_v4_regex)
+    end
+    
+    it "generates unique UUIDs" do
+      uuid1 = Learnosity::Sdk::Utils::Uuid.generate
+      uuid2 = Learnosity::Sdk::Utils::Uuid.generate
+      
+      expect(uuid1).not_to eq(uuid2)
+    end
+    
+    it "is accessible via Learnosity::Sdk::Uuid" do
+      expect(Learnosity::Sdk::Uuid).to eq(Learnosity::Sdk::Utils::Uuid)
+      expect(Learnosity::Sdk::Uuid).to respond_to(:generate)
+    end
+    
+    it "generates 1000 unique UUIDs" do
+      uuids = Set.new
+      
+      1000.times do
+        uuids.add(Learnosity::Sdk::Utils::Uuid.generate)
+      end
+      
+      expect(uuids.size).to eq(1000)
+    end
+  end
+end
+
+# vim: sw=2
+


### PR DESCRIPTION
This PR adds a UUID generation utility (Learnosity::Sdk::Uuid.generate()) to the Ruby SDK, achieving feature parity with the Python and other SDKs. While the implementation is a lightweight wrapper around Ruby's existing SecureRandom.uuid, it provides consistency across Learnosity SDKs, allowing developers to use the same API patterns regardless of language. All documentation and examples have been updated to use the new SDK utility instead of requiring the external securerandom package directly. This is a non-breaking, purely additive change that simplifies the developer experience for new users following tutorials while maintaining backward compatibility for existing implementations. All tests pass.