### PR TITLE
Add GitHub Actions CI workflow for unit tests across supported Ruby v…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.1', '3.2', '3.3', '3.4']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: Run unit tests
+        run: bundle exec rake spec SPEC=spec/learnosity/*


### PR DESCRIPTION
Replaces the removed Travis CI with a GitHub Actions workflow that runs unit tests against all currently supported Ruby versions (3.1, 3.2, 3.3, 3.4).

Triggers on pushes to master and on PRs targeting master.